### PR TITLE
Fix source URL 

### DIFF
--- a/VES-ZW-WAL-008.yaml
+++ b/VES-ZW-WAL-008.yaml
@@ -97,7 +97,7 @@ blueprint:
       default: []
       selector:
         action: {}
-  source_url: https://github.com/beerygaz/ha-bp-VES-ZW-WAL-008
+  source_url: https://github.com/beerygaz/ha-bp-VES-ZW-WAL-008/blob/main/VES-ZW-WAL-008.yaml
 mode: single
 max_exceeded: silent
 variables:


### PR DESCRIPTION
Source URL's in the blueprint need to refer to the YAML file, not the repo